### PR TITLE
Attachments file were not closed

### DIFF
--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -66,6 +66,7 @@ class MailMsg:
 
             part.set_payload(await file.read())
             encode_base64(part)
+            await file.close()
 
             if file_meta and "headers" in file_meta:
                 for header in file_meta["headers"].keys():


### PR DESCRIPTION
When enabling ` PYTHONTRACEMALLOC=1` I could see that when passing `attachments` files to `MessageSchema`, there are not closed

I receive this kind of error
````
app/tests/test_rental.py::test_delete_rental_with_bookings
  /root/.cache/pypoetry/virtualenvs/renting-HtI6FuDW-py3.9/lib/python3.9/site-packages/sentry_sdk/integrations/threading.py:67: ResourceWarning: unclosed file <_io.BufferedReader name='./static/rentals/5840ad8b-359c-4140-bc64-f0994f7e07ec/bookings/2022-09-07/contract_en.pdf'>
    return old_run_func(self, *a, **kw)
 ```
